### PR TITLE
claude/add-missing-docs-hRKWl

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { Terminal, MessageSquare, Sparkles } from 'lucide-react';
+import { MessageSquare, Sparkles } from 'lucide-react';
+import TerminalIcon from '@/components/icons/TerminalIcon';
 
 export default function Dashboard() {
   const [agents, setAgents] = useState<any[]>([]);
@@ -115,8 +116,7 @@ export default function Dashboard() {
         <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
             <div className="relative">
-              <Terminal className="w-6 h-6 text-accent-blue" />
-              <div className="absolute inset-0 blur-md bg-accent-blue/30" />
+              <TerminalIcon className="w-6 h-6 text-accent-blue" />
             </div>
             <span className="text-xl font-bold">stick.ai</span>
           </Link>

--- a/app/docs/[slug]/page.tsx
+++ b/app/docs/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
-import { Terminal, ArrowLeft, ArrowRight, BookOpen } from 'lucide-react';
+import { ArrowLeft, ArrowRight, BookOpen } from 'lucide-react';
+import TerminalIcon from '@/components/icons/TerminalIcon';
 
 // Documentation content for each page
 const documentationContent: Record<string, {
@@ -1123,14 +1124,13 @@ export default function DocPage({ params }: { params: { slug: string } }) {
           <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
             <Link href="/" className="flex items-center gap-2">
               <div className="relative">
-                <Terminal className="w-6 h-6 text-accent-blue" />
-                <div className="absolute inset-0 blur-md bg-accent-blue/30" />
+                <TerminalIcon className="w-6 h-6 text-accent-blue" />
               </div>
               <span className="text-xl font-bold">stick.ai</span>
             </Link>
           </div>
         </nav>
-        
+
         <div className="pt-32 text-center">
           <h1 className="text-4xl font-bold mb-4">Page Not Found</h1>
           <p className="text-zinc-400 mb-8">The documentation page "{slug}" doesn't exist.</p>
@@ -1149,8 +1149,7 @@ export default function DocPage({ params }: { params: { slug: string } }) {
         <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
             <div className="relative">
-              <Terminal className="w-6 h-6 text-accent-blue" />
-              <div className="absolute inset-0 blur-md bg-accent-blue/30" />
+              <TerminalIcon className="w-6 h-6 text-accent-blue" />
             </div>
             <span className="text-xl font-bold">stick.ai</span>
           </Link>

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { Terminal, ArrowRight, BookOpen } from 'lucide-react';
+import { ArrowRight, BookOpen } from 'lucide-react';
 
 import ProIcon from '@/components/icons/ProIcon';
+import TerminalIcon from '@/components/icons/TerminalIcon';
 
 const documentation = [
   {
@@ -66,8 +67,7 @@ export default function Documentation() {
         <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
             <div className="relative">
-              <Terminal className="w-6 h-6 text-accent-blue" />
-              <div className="absolute inset-0 blur-md bg-accent-blue/30" />
+              <TerminalIcon className="w-6 h-6 text-accent-blue" />
             </div>
             <span className="text-xl font-bold">stick.ai</span>
           </Link>

--- a/app/examples/page.tsx
+++ b/app/examples/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Terminal, Bot, Search, Code, BarChart, MessageSquare, Copy, Check } from 'lucide-react';
+import { Bot, Search, Code, BarChart, MessageSquare, Copy, Check } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import SparklesIcon from '@/components/icons/SparklesIcon';
+import TerminalIcon from '@/components/icons/TerminalIcon';
 
 const examples = [
   {
@@ -108,8 +109,7 @@ export default function Examples() {
         <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
             <div className="relative">
-              <Terminal className="w-6 h-6 text-accent-blue" />
-              <div className="absolute inset-0 blur-md bg-accent-blue/30" />
+              <TerminalIcon className="w-6 h-6 text-accent-blue" />
             </div>
             <span className="text-xl font-bold">stick.ai</span>
           </Link>

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Terminal, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import ProIcon from '@/components/icons/ProIcon';
+import TerminalIcon from '@/components/icons/TerminalIcon';
 import AgentBuilder from '@/components/builder/AgentBuilder';
 import AgentPreview from '@/components/builder/AgentPreview';
 import AgentTester from '@/components/builder/AgentTester';
@@ -30,8 +31,7 @@ export default function Playground() {
         <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
             <div className="relative">
-              <Terminal className="w-6 h-6 text-accent-blue" />
-              <div className="absolute inset-0 blur-md bg-accent-blue/30" />
+              <TerminalIcon className="w-6 h-6 text-accent-blue" />
             </div>
             <span className="text-xl font-bold">stick.ai</span>
           </Link>


### PR DESCRIPTION
Replace inconsistent Terminal icon from lucide-react with custom TerminalIcon component across all pages for unified brand identity.

Changes:
- Update docs, dashboard, examples, and playground pages
- Use custom animated TerminalIcon with gradients consistently
- Remove unnecessary blur wrapper (already in TerminalIcon)
- Fix 404 page logo in docs/[slug]

All pages now display the same professional, animated brand logo. Build verified successful (32 pages generated).